### PR TITLE
canonical redirect, documentation

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,4 +1,6 @@
-# https://www.df.eu/blog/performanceoptimierung/
+# Apache server settings
+# rewrite to canonical https://www.ingo-steinke.de
+# optimize caching and compression
 
 <IfModule mod_expires.c>
 ExpiresActive on
@@ -46,4 +48,4 @@ RewriteRule .* https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
 # Now, rewrite any request to the wrong domain to use www.
 # [NC] is a case-insensitive match
 RewriteCond %{HTTP_HOST} !^www\. [NC]
-RewriteRule .* https://www.%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
+RewriteRule .* https://www.ingo-steinke.de%{REQUEST_URI} [L,R=301]

--- a/README.md
+++ b/README.md
@@ -25,13 +25,12 @@ npx stylelint "**/*.css" --fix && eleventy && node_modules/postcss-cli/bin/postc
 ## TODO
 
 * [x] to-do list
-* [ ] description
+* [x] description
 * [x] link to changelog
 * [x] set up local preview
 * [x] set up deployment (JAMStack)
-* [ ] set up css bundling (using [https://github.com/addyosmani/critical](critical)?)
+* [x] set up css optimization
 * [ ] set up local testing
-* [ ] add more content
+* [x] add more content
 * [ ] add demo, design, more fancy css stuff ...
-* [ ] like dark theme switcher with system default
 * [ ] language switcher with system default


### PR DESCRIPTION
Redirect any request, if necessary, to canonical https://www.ingo-steinke.de/
necessary for alias domains on German webhost,
probably irrelevant for netlify cloud deployment.